### PR TITLE
fix delegate registration fee

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwf-nano",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "LWF Nano",
   "main": "./build/main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwf-nano",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "LWF Nano",
   "homepage": "https://github.com/lwfcoin/lwf-nano",
   "bugs": "https://github.com/lwfcoin/lwf-nano/issues",

--- a/src/constants/fees.js
+++ b/src/constants/fees.js
@@ -1,6 +1,6 @@
 export default {
   setSecondPassphrase: 5e8,
   send: 0.1e8,
-  registerDelegate: 25e8,
+  registerDelegate: 5e8,
   vote: 1e8,
 };


### PR DESCRIPTION
Wallet now requires 5 lwf fee instead of 25 to register a delegate.